### PR TITLE
Expand default props to include canvas props

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/brianzinn/babylonjs-hook"
   },
   "scripts": {
-    "lint": "tslint  --project tsconfig.json -t codeFrame 'src/**/*.tsx'",
+    "lint": "tslint --project tsconfig.json -t codeFrame 'src/**/*.tsx'",
     "prebuild": "rimraf dist",
     "build": "rollup -c rollup.config.ts && tsc -d --emitDeclarationOnly --declarationDir dist/types",
     "start": "rollup -c rollup.config.ts -w",

--- a/src/babylonjs-hook.tsx
+++ b/src/babylonjs-hook.tsx
@@ -100,7 +100,7 @@ export const useCamera = <T extends Camera>(createCameraFn: (scene: Scene) => T,
 
         const camera: T = createCameraFn(scene);
         if (autoAttach === true) {
-            const canvas: HTMLCanvasElement = scene.getEngine()!.getRenderingCanvas()!;
+            const canvas: HTMLCanvasElement = scene.getEngine().getRenderingCanvas()!;
 
             // This attaches the camera to the canvas - adding extra parameters breaks backwards compatibility
             // https://github.com/BabylonJS/Babylon.js/pull/9192 (keep canvas to work with < 4.2 beta-13)
@@ -114,7 +114,7 @@ export const useCamera = <T extends Camera>(createCameraFn: (scene: Scene) => T,
         return () => {
             if (autoAttach === true) {
                 // canvas is only needed for < 4.1
-                const canvas: HTMLCanvasElement = scene.getEngine()!.getRenderingCanvas()!;
+                const canvas: HTMLCanvasElement = scene.getEngine().getRenderingCanvas()!;
                 camera.detachControl(canvas);
             }
             camera.dispose();

--- a/src/babylonjs-hook.tsx
+++ b/src/babylonjs-hook.tsx
@@ -27,7 +27,7 @@ export type OnFrameRenderFn = (eventData: Scene, eventState: EventState) => void
 
 /**
  * Register a callback for before the scene renders.
- * 
+ *
  * @param callback called using onBeforeRender functionality of scene
  * @param mask the mask used to filter observers
  * @param insertFirst if true will be inserted at first position, if false (default) will be last position.
@@ -54,7 +54,7 @@ export const useBeforeRender = (callback: OnFrameRenderFn, mask?: number, insert
 
 /**
  * Register a callback for after the scene renders.
- * 
+ *
  * @param callback called using onBeforeRender functionality of scene
  * @param mask the mask used to filter observers
  * @param insertFirst if true will be inserted at first position, if false (default) will be last position.

--- a/src/babylonjs-hook.tsx
+++ b/src/babylonjs-hook.tsx
@@ -19,7 +19,6 @@ export type BabylonjsProps = {
     sceneOptions?: SceneOptions
     onSceneReady: (scene: Scene) => void
     onRender?: (scene: Scene) => void
-    id: string
     children?: React.ReactNode
 };
 
@@ -124,7 +123,7 @@ export const useCamera = <T extends Camera>(createCameraFn: (scene: Scene) => T,
     return cameraRef.current;
 }
 
-export default (props: BabylonjsProps) => {
+export default (props: BabylonjsProps & React.CanvasHTMLAttributes<HTMLCanvasElement>) => {
     const reactCanvas = useRef<Nullable<HTMLCanvasElement>>(null);
     const { antialias, engineOptions, adaptToDeviceRatio, sceneOptions, onRender, onSceneReady, renderChildrenWhenReady, children, ...rest } = props;
 


### PR DESCRIPTION
I was having an issue because I wanted to pass props like `className` and `style` into the canvas that's inside the default component.  It can technically be done from a code level because of the use of `...rest` from the props, but Typescript complains because `BabylonjsProps` doesn't include them.

Rather than including them explicitly, I thought it would be easier and more accessible for other people's use cases to include all the the valid props for a typical canvas element.

The first commit (67d47f8) just removes extra whitespace.  My editor did that.

The second commit (b6980c1) removes some assertions that ts-lint was complaining about.  According to the types, `scene.getEngine()` can only return an instance of `Engine`.  It doesn't appear to be `Nullable`, so I think this is okay.

The third commit (00a36f1) adds the extra props to the default component.

Please let me know if there's anything more I should do to get this ready for merging.  Thank you!